### PR TITLE
upload-doc-modal

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -3,6 +3,7 @@ import React, { useState } from 'react';
 import { Typography, IconButton, Menu, MenuItem, Box } from '@mui/material';
 import DeleteTwoToneIcon from '@mui/icons-material/DeleteTwoTone';
 import MoreVertTwoToneIcon from '@mui/icons-material/MoreVertTwoTone';
+import UploadDocModalBtn from './modals/upload-doc-modal/UploadDocModalBtn';
 
 const Header = () => {
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
@@ -50,7 +51,7 @@ const Header = () => {
           anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
           transformOrigin={{ vertical: 'top', horizontal: 'right' }}
         >
-          <MenuItem onClick={handleMenuClose}>Option 1</MenuItem>
+          <UploadDocModalBtn handleMenuClose={handleMenuClose} />
           <MenuItem onClick={handleMenuClose}>Option 2</MenuItem>
         </Menu>
       </Box>

--- a/src/components/modals/upload-doc-modal/UploadDocModal.tsx
+++ b/src/components/modals/upload-doc-modal/UploadDocModal.tsx
@@ -1,0 +1,206 @@
+// Modal for uploading a file
+
+import React, { useState } from 'react';
+import {
+  Dialog,
+  DialogTitle,
+  DialogActions,
+  DialogContent,
+  IconButton,
+  Typography,
+  Box,
+  Button,
+  List,
+  ListItem,
+  ListItemIcon,
+} from '@mui/material';
+import CloseIcon from '@mui/icons-material/Close';
+import CloudUploadIcon from '@mui/icons-material/CloudUpload';
+import DescriptionIcon from '@mui/icons-material/Description';
+import DeleteIcon from '@mui/icons-material/Delete';
+
+interface UploadDocModalProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+const UploadDocModal: React.FC<UploadDocModalProps> = ({ open, onClose }) => {
+
+  const [selectedFile, setSelectedFile] = useState<File | null>(null);
+
+  const handleFileDrop = (event: React.DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    const file = event.dataTransfer.files[0];
+    setSelectedFile(file);
+  };
+
+  const handleFileSelect = (event: React.ChangeEvent<HTMLInputElement>) => {
+    if (event.target.files && event.target.files[0]) {
+      const file = event.target.files[0];
+      setSelectedFile(file);
+    }
+  };
+
+  const handleRemoveFile = () => {
+    setSelectedFile(null);
+  };
+
+  const handleUpload = () => {
+    // Implement upload logic here....
+    console.log('Uploading:', selectedFile);
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      maxWidth="sm"
+      fullWidth
+      disableEnforceFocus
+      disableRestoreFocus
+    >
+      <DialogTitle>
+        <Typography variant="h6" component="span" fontWeight="bold" fontSize={25}>
+          Upload File
+        </Typography>
+        <IconButton
+          aria-label="close"
+          onClick={onClose}
+          sx={{ position: 'absolute', right: 8, top: 8, fontSize: 30 }}
+        >
+          <CloseIcon sx={{ fontSize: 30 }} />
+        </IconButton>
+      </DialogTitle>
+
+      <DialogContent sx={{ paddingBottom: '10px' }}>
+      <Box
+        onDragOver={(event) => {
+          event.preventDefault();
+          event.currentTarget.style.backgroundColor = '#f0f0f0';
+        }}
+        onDragLeave={(event) => {
+          event.currentTarget.style.backgroundColor = 'transparent';
+        }}
+        onDrop={(event) => {
+          handleFileDrop(event);
+          event.currentTarget.style.backgroundColor = 'transparent';
+        }}
+        sx={{
+          border: '2px dashed #ccc',
+          borderRadius: '8px',
+          padding: '30px',
+          textAlign: 'center',
+          color: '#666',
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          gap: 1,
+          height: '200px',
+        }}
+      >
+        <CloudUploadIcon fontSize="inherit" sx={{ fontSize: 80, color: 'black' }} />
+        <Typography variant="h6">Drop File Here</Typography>
+        <Typography variant="body2">Supported formats: PDF, Word</Typography>
+        <Typography variant="body2">Or</Typography>
+
+        <Button id='browse-files' color="inherit" component="label" sx={{ fontSize: 18 }}>
+          Browse File
+          <input type="file" hidden accept=".pdf,.doc,.docx" onChange={handleFileSelect} />
+        </Button>
+      </Box>
+
+      {selectedFile && (
+        <Box
+          sx={{
+            backgroundColor: '#333',
+            color: 'white',
+            borderRadius: '8px',
+            margin: '0px 16px',
+            marginTop: '16px',
+          }}
+        >
+          <List sx={{ padding: '0px' }}>
+            <ListItem sx={{ padding: '2px 15px' }}>
+              <ListItemIcon sx={{ minWidth: '5%' }}>
+                <DescriptionIcon sx={{ color: 'white', fontSize: 40 }} />
+              </ListItemIcon>
+              <Box
+                sx={{
+                  width: '90%',
+                  overflow: 'hidden',
+                  display: 'flex',
+                  flexDirection: 'column',
+                  alignItems: 'start',
+                }}
+              >
+                <Typography
+                  sx={{
+                    whiteSpace: 'nowrap',
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    maxWidth: '90%',
+                    paddingLeft: '20px',
+                  }}
+                >
+                  {selectedFile.name}
+                </Typography>
+                <Typography
+                  sx={{
+                    paddingLeft: '20px',
+                  }}
+                >
+                  {`${(selectedFile.size / 1024).toFixed(2)} KB`}
+                </Typography>
+              </Box>
+              <Box sx={{ width: '5%', display: 'flex', justifyContent: 'flex-end' }}>
+                <IconButton
+                  edge="end"
+                  aria-label="delete"
+                  onClick={handleRemoveFile}
+                  sx={{
+                    fontSize: 30,
+                    transition: 'opacity 0.15s, background-color 0.15s',
+                    '&:hover': {
+                      opacity: 0.7,
+                      backgroundColor: 'rgba(255, 255, 255, 0.1)',
+                    },
+                  }}
+                >
+                  <DeleteIcon sx={{ color: 'white', fontSize: 40 }} />
+                </IconButton>
+              </Box>
+            </ListItem>
+          </List>
+        </Box>
+      )}
+    </DialogContent>
+
+
+      <DialogActions sx={{ paddingBottom: '40px', paddingRight: '24px' }}>
+        <Button onClick={onClose} color="inherit" sx={{ fontSize: 15 }}>
+          Cancel
+        </Button>
+        <Button
+          onClick={handleUpload}
+          variant="contained"
+          sx={{
+            backgroundColor: '#4D4D4D',
+            color: 'white',
+            transition: 'opacity 0.15s',
+            fontSize: 15,
+            '&:hover': {
+              backgroundColor: '#4D4D4D',
+              opacity: 0.6,
+            },
+          }}
+          disabled={!selectedFile}
+        >
+          Upload
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default UploadDocModal;

--- a/src/components/modals/upload-doc-modal/UploadDocModal.tsx
+++ b/src/components/modals/upload-doc-modal/UploadDocModal.tsx
@@ -25,7 +25,6 @@ interface UploadDocModalProps {
 }
 
 const UploadDocModal: React.FC<UploadDocModalProps> = ({ open, onClose }) => {
-
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
 
   const handleFileDrop = (event: React.DragEvent<HTMLDivElement>) => {
@@ -78,109 +77,108 @@ const UploadDocModal: React.FC<UploadDocModalProps> = ({ open, onClose }) => {
       </DialogTitle>
 
       <DialogContent sx={{ paddingBottom: '10px' }}>
-      <Box
-        onDragOver={(event) => {
-          event.preventDefault();
-          event.currentTarget.style.backgroundColor = '#f0f0f0';
-        }}
-        onDragLeave={(event) => {
-          event.currentTarget.style.backgroundColor = 'transparent';
-        }}
-        onDrop={(event) => {
-          handleFileDrop(event);
-          event.currentTarget.style.backgroundColor = 'transparent';
-        }}
-        sx={{
-          border: '2px dashed #ccc',
-          borderRadius: '8px',
-          padding: '30px',
-          textAlign: 'center',
-          color: '#666',
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'center',
-          justifyContent: 'center',
-          gap: 1,
-          height: '200px',
-        }}
-      >
-        <CloudUploadIcon fontSize="inherit" sx={{ fontSize: 80, color: 'black' }} />
-        <Typography variant="h6">Drop File Here</Typography>
-        <Typography variant="body2">Supported formats: PDF, Word</Typography>
-        <Typography variant="body2">Or</Typography>
-
-        <Button id='browse-files' color="inherit" component="label" sx={{ fontSize: 18 }}>
-          Browse File
-          <input type="file" hidden accept=".pdf,.doc,.docx" onChange={handleFileSelect} />
-        </Button>
-      </Box>
-
-      {selectedFile && (
         <Box
+          onDragOver={(event) => {
+            event.preventDefault();
+            event.currentTarget.style.backgroundColor = '#f0f0f0';
+          }}
+          onDragLeave={(event) => {
+            event.currentTarget.style.backgroundColor = 'transparent';
+          }}
+          onDrop={(event) => {
+            handleFileDrop(event);
+            event.currentTarget.style.backgroundColor = 'transparent';
+          }}
           sx={{
-            backgroundColor: '#333',
-            color: 'white',
+            border: '2px dashed #ccc',
             borderRadius: '8px',
-            margin: '0px 16px',
-            marginTop: '16px',
+            padding: '30px',
+            textAlign: 'center',
+            color: '#666',
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            justifyContent: 'center',
+            gap: 1,
+            height: '200px',
           }}
         >
-          <List sx={{ padding: '0px' }}>
-            <ListItem sx={{ padding: '2px 15px' }}>
-              <ListItemIcon sx={{ minWidth: '5%' }}>
-                <DescriptionIcon sx={{ color: 'white', fontSize: 30 }} />
-              </ListItemIcon>
-              <Box
-                sx={{
-                  width: '90%',
-                  overflow: 'hidden',
-                  display: 'flex',
-                  flexDirection: 'column',
-                  alignItems: 'start',
-                }}
-              >
-                <Typography
-                  sx={{
-                    whiteSpace: 'nowrap',
-                    overflow: 'hidden',
-                    textOverflow: 'ellipsis',
-                    maxWidth: '90%',
-                    paddingLeft: '20px',
-                  }}
-                >
-                  {selectedFile.name}
-                </Typography>
-                <Typography
-                  sx={{
-                    paddingLeft: '20px',
-                  }}
-                >
-                  {`${(selectedFile.size / 1024).toFixed(2)} KB`}
-                </Typography>
-              </Box>
-              <Box sx={{ width: '5%', display: 'flex', justifyContent: 'flex-end' }}>
-                <IconButton
-                  edge="end"
-                  aria-label="delete"
-                  onClick={handleRemoveFile}
-                  sx={{
-                    fontSize: 30,
-                    transition: 'opacity 0.15s, background-color 0.15s',
-                    '&:hover': {
-                      opacity: 0.7,
-                      backgroundColor: 'rgba(255, 255, 255, 0.1)',
-                    },
-                  }}
-                >
-                  <DeleteIcon sx={{ color: 'white', fontSize: 30 }} />
-                </IconButton>
-              </Box>
-            </ListItem>
-          </List>
-        </Box>
-      )}
-    </DialogContent>
+          <CloudUploadIcon fontSize="inherit" sx={{ fontSize: 80, color: 'black' }} />
+          <Typography variant="h6">Drop File Here</Typography>
+          <Typography variant="body2">Supported formats: PDF, Word</Typography>
+          <Typography variant="body2">Or</Typography>
 
+          <Button id="browse-files" color="inherit" component="label" sx={{ fontSize: 18 }}>
+            Browse File
+            <input type="file" hidden accept=".pdf,.doc,.docx" onChange={handleFileSelect} />
+          </Button>
+        </Box>
+
+        {selectedFile && (
+          <Box
+            sx={{
+              backgroundColor: '#333',
+              color: 'white',
+              borderRadius: '8px',
+              margin: '0px 16px',
+              marginTop: '16px',
+            }}
+          >
+            <List sx={{ padding: '0px' }}>
+              <ListItem sx={{ padding: '2px 15px' }}>
+                <ListItemIcon sx={{ minWidth: '5%' }}>
+                  <DescriptionIcon sx={{ color: 'white', fontSize: 30 }} />
+                </ListItemIcon>
+                <Box
+                  sx={{
+                    width: '90%',
+                    overflow: 'hidden',
+                    display: 'flex',
+                    flexDirection: 'column',
+                    alignItems: 'start',
+                  }}
+                >
+                  <Typography
+                    sx={{
+                      whiteSpace: 'nowrap',
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                      maxWidth: '90%',
+                      paddingLeft: '20px',
+                    }}
+                  >
+                    {selectedFile.name}
+                  </Typography>
+                  <Typography
+                    sx={{
+                      paddingLeft: '20px',
+                    }}
+                  >
+                    {`${(selectedFile.size / 1024).toFixed(2)} KB`}
+                  </Typography>
+                </Box>
+                <Box sx={{ width: '5%', display: 'flex', justifyContent: 'flex-end' }}>
+                  <IconButton
+                    edge="end"
+                    aria-label="delete"
+                    onClick={handleRemoveFile}
+                    sx={{
+                      fontSize: 30,
+                      transition: 'opacity 0.15s, background-color 0.15s',
+                      '&:hover': {
+                        opacity: 0.7,
+                        backgroundColor: 'rgba(255, 255, 255, 0.1)',
+                      },
+                    }}
+                  >
+                    <DeleteIcon sx={{ color: 'white', fontSize: 30 }} />
+                  </IconButton>
+                </Box>
+              </ListItem>
+            </List>
+          </Box>
+        )}
+      </DialogContent>
 
       <DialogActions sx={{ paddingBottom: '40px', paddingRight: '24px' }}>
         <Button onClick={handleCloseModal} color="inherit" sx={{ fontSize: 15 }}>

--- a/src/components/modals/upload-doc-modal/UploadDocModal.tsx
+++ b/src/components/modals/upload-doc-modal/UploadDocModal.tsx
@@ -50,10 +50,15 @@ const UploadDocModal: React.FC<UploadDocModalProps> = ({ open, onClose }) => {
     console.log('Uploading:', selectedFile);
   };
 
+  const handleCloseModal = () => {
+    setSelectedFile(null);
+    onClose();
+  };
+
   return (
     <Dialog
       open={open}
-      onClose={onClose}
+      onClose={handleCloseModal}
       maxWidth="sm"
       fullWidth
       disableEnforceFocus
@@ -65,7 +70,7 @@ const UploadDocModal: React.FC<UploadDocModalProps> = ({ open, onClose }) => {
         </Typography>
         <IconButton
           aria-label="close"
-          onClick={onClose}
+          onClick={handleCloseModal}
           sx={{ position: 'absolute', right: 8, top: 8, fontSize: 30 }}
         >
           <CloseIcon sx={{ fontSize: 30 }} />
@@ -123,7 +128,7 @@ const UploadDocModal: React.FC<UploadDocModalProps> = ({ open, onClose }) => {
           <List sx={{ padding: '0px' }}>
             <ListItem sx={{ padding: '2px 15px' }}>
               <ListItemIcon sx={{ minWidth: '5%' }}>
-                <DescriptionIcon sx={{ color: 'white', fontSize: 40 }} />
+                <DescriptionIcon sx={{ color: 'white', fontSize: 30 }} />
               </ListItemIcon>
               <Box
                 sx={{
@@ -167,7 +172,7 @@ const UploadDocModal: React.FC<UploadDocModalProps> = ({ open, onClose }) => {
                     },
                   }}
                 >
-                  <DeleteIcon sx={{ color: 'white', fontSize: 40 }} />
+                  <DeleteIcon sx={{ color: 'white', fontSize: 30 }} />
                 </IconButton>
               </Box>
             </ListItem>
@@ -178,7 +183,7 @@ const UploadDocModal: React.FC<UploadDocModalProps> = ({ open, onClose }) => {
 
 
       <DialogActions sx={{ paddingBottom: '40px', paddingRight: '24px' }}>
-        <Button onClick={onClose} color="inherit" sx={{ fontSize: 15 }}>
+        <Button onClick={handleCloseModal} color="inherit" sx={{ fontSize: 15 }}>
           Cancel
         </Button>
         <Button

--- a/src/components/modals/upload-doc-modal/UploadDocModalBtn.tsx
+++ b/src/components/modals/upload-doc-modal/UploadDocModalBtn.tsx
@@ -10,7 +10,7 @@ interface UploadDocModalBtnProps {
 
 export default function UploadDocModalBtn({  handleMenuClose }: UploadDocModalBtnProps) {
     
-  const [docModalOpen, setDocModalOpen] = useState(true);
+  const [docModalOpen, setDocModalOpen] = useState(false);
 
   const openDocUploadModal = () =>{
     handleMenuClose();

--- a/src/components/modals/upload-doc-modal/UploadDocModalBtn.tsx
+++ b/src/components/modals/upload-doc-modal/UploadDocModalBtn.tsx
@@ -1,0 +1,28 @@
+
+import {  MenuItem } from '@mui/material';
+
+import React, { useState } from 'react';
+import UploadDocModal from './UploadDocModal';
+
+interface UploadDocModalBtnProps {
+  handleMenuClose: () => void;
+}
+
+export default function UploadDocModalBtn({  handleMenuClose }: UploadDocModalBtnProps) {
+    
+  const [docModalOpen, setDocModalOpen] = useState(true);
+
+  const openDocUploadModal = () =>{
+    handleMenuClose();
+    setDocModalOpen(true);
+  }
+
+  const closeDocModal = () => setDocModalOpen(false);
+
+  return (
+    <>
+     <MenuItem onClick={openDocUploadModal}>Upload Document</MenuItem>
+     <UploadDocModal open={docModalOpen} onClose={closeDocModal} />
+    </>
+  );
+}

--- a/src/components/modals/upload-doc-modal/UploadDocModalBtn.tsx
+++ b/src/components/modals/upload-doc-modal/UploadDocModalBtn.tsx
@@ -1,5 +1,4 @@
-
-import {  MenuItem } from '@mui/material';
+import { MenuItem } from '@mui/material';
 
 import React, { useState } from 'react';
 import UploadDocModal from './UploadDocModal';
@@ -8,21 +7,20 @@ interface UploadDocModalBtnProps {
   handleMenuClose: () => void;
 }
 
-export default function UploadDocModalBtn({  handleMenuClose }: UploadDocModalBtnProps) {
-    
+export default function UploadDocModalBtn({ handleMenuClose }: UploadDocModalBtnProps) {
   const [docModalOpen, setDocModalOpen] = useState(false);
 
-  const openDocUploadModal = () =>{
+  const openDocUploadModal = () => {
     handleMenuClose();
     setDocModalOpen(true);
-  }
+  };
 
   const closeDocModal = () => setDocModalOpen(false);
 
   return (
     <>
-     <MenuItem onClick={openDocUploadModal}>Upload Document</MenuItem>
-     <UploadDocModal open={docModalOpen} onClose={closeDocModal} />
+      <MenuItem onClick={openDocUploadModal}>Upload Document</MenuItem>
+      <UploadDocModal open={docModalOpen} onClose={closeDocModal} />
     </>
   );
 }


### PR DESCRIPTION
Finished up the doc upload but may need some changes

Notes
1. Created a modal directory for better organization of modal components.
2. Developed a button component to trigger the modal and replaced the button in the header, consolidating state management to avoid header conflicts.
3. The modal currently supports drag and drop or browse for selecting documents, but the upload functionality hasn't been implemented yet. (Currently, the document data is only logged.)
4. File format restrictions haven't been applied yet. The wireframe specifies PNG and JPG, but are doing PDFs and Word docs right?

Issues
1. Still new to using git in a collaborative environment and ran into some issues merging my branch with the chat - but I think I sorted it out
2. Testing - New to jest and tried making a test and it worked, but not entirely sure how to make sure It was done properly

Images
<img width="762" alt="image" src="https://github.com/user-attachments/assets/57a6cef0-a4f1-4c34-842e-1326b0dce484" />


<img width="1061" alt="image" src="https://github.com/user-attachments/assets/d24fcdb6-851b-452d-b6f2-92a3f158d520" />
