### PR TITLE
created api modal and open/close btn

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,9 +1,10 @@
 'use client';
 import React, { useState } from 'react';
-import { Typography, IconButton, Menu, MenuItem, Box } from '@mui/material';
+import { Typography, IconButton, Menu, Box } from '@mui/material';
 import DeleteTwoToneIcon from '@mui/icons-material/DeleteTwoTone';
 import MoreVertTwoToneIcon from '@mui/icons-material/MoreVertTwoTone';
 import UploadDocModalBtn from './modals/upload-doc-modal/UploadDocModalBtn';
+import OpenApiKeyModalBtn from './modals/upload-api-key-modal/OpenApiKeyModalBtn';
 
 const Header = () => {
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
@@ -52,7 +53,7 @@ const Header = () => {
           transformOrigin={{ vertical: 'top', horizontal: 'right' }}
         >
           <UploadDocModalBtn handleMenuClose={handleMenuClose} />
-          <MenuItem onClick={handleMenuClose}>Option 2</MenuItem>
+          <OpenApiKeyModalBtn handleMenuClose={handleMenuClose} />
         </Menu>
       </Box>
     </Box>

--- a/src/components/modals/upload-api-key-modal/ApiKeyModal.tsx
+++ b/src/components/modals/upload-api-key-modal/ApiKeyModal.tsx
@@ -1,5 +1,7 @@
+// commented out various useState and onChange for future use with API key and selected models
+
 'use client';
-import React, { useState }  from 'react';
+import React from 'react';
 import {
   Dialog,
   DialogTitle,
@@ -21,16 +23,18 @@ interface ApiKeyProps {
 }
 
 const ApiKeyModal: React.FC<ApiKeyProps> = ({ open, onClose }) => {
-  const [apiKeyVal, setApiKeyVal] = useState('');
-  const [selectedModel, setSelectedModel] = useState('');
+  // Commenting these out for future use
+  //const [apiKeyVal, setApiKeyVal] = useState('');
+  //const [selectedModel, setSelectedModel] = useState('');
   if (!open) return null;
 
   const closeModal = () => {
     onClose();
   };
 
+  // Future function for submit button
   //const handleEnter: {
-  // function to enter/submit
+
   //}
 
   const modelDropdownChoice = [
@@ -88,10 +92,7 @@ const ApiKeyModal: React.FC<ApiKeyProps> = ({ open, onClose }) => {
           </Typography>
 
           <Box
-            sx={{ display: 'flex',
-              alignItems: 'flex-end',
-              width: '100%',
-              marginBottom: '15px' }}
+            sx={{ display: 'flex', alignItems: 'flex-end', width: '100%', marginBottom: '15px' }}
           >
             <TextField
               id="api-input"
@@ -104,9 +105,10 @@ const ApiKeyModal: React.FC<ApiKeyProps> = ({ open, onClose }) => {
               }
               size="small"
               fullWidth
-              onChange={(e) => {
-                setApiKeyVal(e.target.value);
-                }}
+              // Commented out for future use
+              //onChange={(e) => {
+              //setApiKeyVal(e.target.value);
+              //}}
             />
           </Box>
 
@@ -121,9 +123,10 @@ const ApiKeyModal: React.FC<ApiKeyProps> = ({ open, onClose }) => {
             size="small"
             helperText="Please select your model"
             fullWidth
-            onChange={(e) => {
-              setSelectedModel(e.target.value);
-            }}
+            // Commented out for future use
+            //onChange={(e) => {
+            //setSelectedModel(e.target.value);
+            //}}
           >
             {modelDropdownChoice.map((option) => (
               <MenuItem key={option.value} value={option.value}>

--- a/src/components/modals/upload-api-key-modal/ApiKeyModal.tsx
+++ b/src/components/modals/upload-api-key-modal/ApiKeyModal.tsx
@@ -1,5 +1,5 @@
 'use client';
-import React from 'react';
+import React, { useState }  from 'react';
 import {
   Dialog,
   DialogTitle,
@@ -16,12 +16,14 @@ import KeyIcon from '@mui/icons-material/Key';
 import CloseIcon from '@mui/icons-material/Close';
 
 interface ApiKeyProps {
-  onOpen: boolean;
+  open: boolean;
   onClose: () => void;
 }
 
-const ApiKeyModal: React.FC<ApiKeyProps> = ({ onOpen, onClose }) => {
-  if (!onOpen) return null;
+const ApiKeyModal: React.FC<ApiKeyProps> = ({ open, onClose }) => {
+  const [apiKeyVal, setApiKeyVal] = useState('');
+  const [selectedModel, setSelectedModel] = useState('');
+  if (!open) return null;
 
   const closeModal = () => {
     onClose();
@@ -51,7 +53,7 @@ const ApiKeyModal: React.FC<ApiKeyProps> = ({ onOpen, onClose }) => {
 
   return (
     <Dialog
-      open={onOpen}
+      open={open}
       onClose={closeModal}
       maxWidth="sm"
       fullWidth
@@ -86,15 +88,25 @@ const ApiKeyModal: React.FC<ApiKeyProps> = ({ onOpen, onClose }) => {
           </Typography>
 
           <Box
-            sx={{ display: 'flex', alignItems: 'flex-end', width: '100%', marginBottom: '15px' }}
+            sx={{ display: 'flex',
+              alignItems: 'flex-end',
+              width: '100%',
+              marginBottom: '15px' }}
           >
-            <KeyIcon sx={{ color: 'action.active', mr: 1, my: 0.5 }} />
             <TextField
               id="api-input"
               variant="filled"
+              label={
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+                  <KeyIcon sx={{ color: 'action.active', fontSize: 18 }} />
+                  Enter your API key
+                </Box>
+              }
               size="small"
               fullWidth
-              label="Enter your API key"
+              onChange={(e) => {
+                setApiKeyVal(e.target.value);
+                }}
             />
           </Box>
 
@@ -109,6 +121,9 @@ const ApiKeyModal: React.FC<ApiKeyProps> = ({ onOpen, onClose }) => {
             size="small"
             helperText="Please select your model"
             fullWidth
+            onChange={(e) => {
+              setSelectedModel(e.target.value);
+            }}
           >
             {modelDropdownChoice.map((option) => (
               <MenuItem key={option.value} value={option.value}>
@@ -130,6 +145,7 @@ const ApiKeyModal: React.FC<ApiKeyProps> = ({ onOpen, onClose }) => {
 
         <Button //Enter Button
           //onClick={handleEnter}
+          disabled
           variant="contained"
           sx={{
             backgroundColor: '#4D4D4D',

--- a/src/components/modals/upload-api-key-modal/ApiKeyModal.tsx
+++ b/src/components/modals/upload-api-key-modal/ApiKeyModal.tsx
@@ -1,0 +1,152 @@
+'use client';
+import React from 'react';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Box,
+  Button,
+  Typography,
+  IconButton,
+  TextField,
+  MenuItem,
+} from '@mui/material';
+import KeyIcon from '@mui/icons-material/Key';
+import CloseIcon from '@mui/icons-material/Close';
+
+interface ApiKeyProps {
+  onOpen: boolean;
+  onClose: () => void;
+}
+
+const ApiKeyModal: React.FC<ApiKeyProps> = ({ onOpen, onClose }) => {
+  if (!onOpen) return null;
+
+  const closeModal = () => {
+    onClose();
+  };
+
+  //const handleEnter: {
+  // function to enter/submit
+  //}
+
+  const modelDropdownChoice = [
+    {
+      value: 'chatGpt',
+      label: 'Chat GPT',
+    },
+    /* Add other models here
+    {
+
+      value: '',
+      label: '',
+    },
+    {
+      value: '',
+      label: '',
+    }
+     */
+  ];
+
+  return (
+    <Dialog
+      open={onOpen}
+      onClose={closeModal}
+      maxWidth="sm"
+      fullWidth
+      disableEnforceFocus
+      disableRestoreFocus
+    >
+      <DialogTitle>
+        <Typography variant="h6" component="span" fontWeight="bold" fontSize={25}>
+          Add API Key
+        </Typography>
+        <IconButton
+          // top right close button
+          onClick={closeModal}
+          sx={{ position: 'absolute', right: 8, top: 8 }}
+        >
+          <CloseIcon sx={{ fontSize: 30 }} />
+        </IconButton>
+      </DialogTitle>
+      <DialogContent sx={{ paddingBottom: '10px' }}>
+        <Box
+          sx={{
+            padding: '30px',
+            color: '#666',
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 1,
+            height: '200px',
+          }}
+        >
+          <Typography variant="subtitle1" component="span" fontWeight="bold">
+            API Key
+          </Typography>
+
+          <Box
+            sx={{ display: 'flex', alignItems: 'flex-end', width: '100%', marginBottom: '15px' }}
+          >
+            <KeyIcon sx={{ color: 'action.active', mr: 1, my: 0.5 }} />
+            <TextField
+              id="api-input"
+              variant="filled"
+              size="small"
+              fullWidth
+              label="Enter your API key"
+            />
+          </Box>
+
+          <Typography variant="subtitle1" component="span" fontWeight="bold">
+            Model
+          </Typography>
+          <TextField
+            id="model-selection-input"
+            select
+            label=""
+            defaultValue=""
+            size="small"
+            helperText="Please select your model"
+            fullWidth
+          >
+            {modelDropdownChoice.map((option) => (
+              <MenuItem key={option.value} value={option.value}>
+                {option.label}
+              </MenuItem>
+            ))}
+          </TextField>
+        </Box>
+      </DialogContent>
+
+      <DialogActions sx={{ paddingBottom: '40px', paddingRight: '24px' }}>
+        <Button // Cancel button
+          onClick={closeModal}
+          color="inherit"
+          sx={{ fontSize: 15 }}
+        >
+          Cancel
+        </Button>
+
+        <Button //Enter Button
+          //onClick={handleEnter}
+          variant="contained"
+          sx={{
+            backgroundColor: '#4D4D4D',
+            color: 'white',
+            transition: 'opacity 0.15s',
+            fontSize: 15,
+            '&:hover': {
+              backgroundColor: '#4D4D4D',
+              opacity: 0.6,
+            },
+          }}
+        >
+          Enter
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default ApiKeyModal;

--- a/src/components/modals/upload-api-key-modal/OpenApiKeyModalBtn.tsx
+++ b/src/components/modals/upload-api-key-modal/OpenApiKeyModalBtn.tsx
@@ -1,0 +1,28 @@
+import { MenuItem } from '@mui/material';
+
+import React, { useState } from 'react';
+import ApiKeyModal from './ApiKeyModal';
+
+interface OpenApiKeyModalBtnProps {
+  handleMenuClose: () => void;
+}
+
+export default function OpenApiKeyModalBtn({ handleMenuClose }: OpenApiKeyModalBtnProps) {
+  const [openApiModal, setOpenApiModal] = useState<boolean>(false);
+
+  const openApiKeyModal = () => {
+    handleMenuClose();
+    setOpenApiModal(true);
+  };
+
+  const closeApiModal = () => {
+    setOpenApiModal(false);
+  };
+
+  return (
+    <>
+      <MenuItem onClick={openApiKeyModal}>Add API Key and Model</MenuItem>
+      <ApiKeyModal onOpen={openApiModal} onClose={closeApiModal} />
+    </>
+  );
+}

--- a/src/components/modals/upload-api-key-modal/OpenApiKeyModalBtn.tsx
+++ b/src/components/modals/upload-api-key-modal/OpenApiKeyModalBtn.tsx
@@ -22,7 +22,7 @@ export default function OpenApiKeyModalBtn({ handleMenuClose }: OpenApiKeyModalB
   return (
     <>
       <MenuItem onClick={openApiKeyModal}>Add API Key and Model</MenuItem>
-      <ApiKeyModal onOpen={openApiModal} onClose={closeApiModal} />
+      <ApiKeyModal open={openApiModal} onClose={closeApiModal} />
     </>
   );
 }


### PR DESCRIPTION
Built the Add Api Key component with model selection according to the acceptance criteria. Added the functionality to open from the header and close within the modal.

For future backlog tasks, will need actions for the inputs and "enter" button integrated into it for future usability.